### PR TITLE
Do not default chain node

### DIFF
--- a/config.go
+++ b/config.go
@@ -264,7 +264,6 @@ func loadConfig() (*config, error) {
 			BaseFee:       defaultBitcoinBaseFeeMSat,
 			FeeRate:       defaultBitcoinFeeRate,
 			TimeLockDelta: defaultBitcoinTimeLockDelta,
-			Node:          "btcd",
 		},
 		BtcdMode: &btcdConfig{
 			Dir:     defaultBtcdDir,
@@ -280,7 +279,6 @@ func loadConfig() (*config, error) {
 			BaseFee:       defaultLitecoinBaseFeeMSat,
 			FeeRate:       defaultLitecoinFeeRate,
 			TimeLockDelta: defaultLitecoinTimeLockDelta,
-			Node:          "ltcd",
 		},
 		LtcdMode: &btcdConfig{
 			Dir:     defaultLtcdDir,


### PR DESCRIPTION
Fixes #950

When starting lnd, we no longer assume the user is using `btcd` over `bitcoind`.

When you now run `lnd` without bitcoin or litecoin node specified, you get the following error...

```
lnd --rpclisten=localhost:10001 --listen=localhost:10011 --restlisten=localhost:8001
Bitcoin Node: loadConfig: only btcd, bitcoind, and neutrino mode supported for bitcoin at this time
```

Alternatively, we can create a separate error message (similar to the one above) that gives a little more detail that `Node` wasn't provided at all (vs not one of the ones supported)